### PR TITLE
author alias

### DIFF
--- a/content/authors/Ben-Hatch/_index.md
+++ b/content/authors/Ben-Hatch/_index.md
@@ -6,6 +6,10 @@ title: Ben Hatch
 authors:
 - Ben Hatch
 
+#Author Names (alternative spellings etc)
+names:
+- Ben Hatch
+
 # Is this the primary user of the site?
 superuser: false
 
@@ -54,12 +58,13 @@ social:
 - icon: orcid
   icon_pack: fab
   link: https://orcid.org/0000-0002-8762-8444
-- icon: university-logo
-  icon_pack: Custom_University
-  link: https://www.cs.utah.edu/
 - icon: envelope
   icon_pack: fas
   link: mailto:benjamin.hat4@gmail.com 
+- icon: university-logo
+  icon_pack: Custom_University
+  link: https://www.cs.utah.edu/
+
 # Link to a PDF of your resume/CV from the About widget.
 # To enable, copy your resume/CV to `static/files/cv.pdf` and uncomment the lines below.
 # - icon: cv

--- a/content/authors/Chris-Myers/_index.md
+++ b/content/authors/Chris-Myers/_index.md
@@ -5,6 +5,10 @@ title: Chris Myers
 # Username (this should match the folder name)
 authors:
 - Chris Myers
+
+#Author Names (alternative spellings etc)
+names:
+- Chris Myers
 - Chris J. Myers
 - Chris J Myers
 - C Myers

--- a/content/authors/Eric-Yu/_index.md
+++ b/content/authors/Eric-Yu/_index.md
@@ -6,6 +6,10 @@ title: Eric Yu
 authors:
 - Eric Yu
 
+#Author Names (alternative spellings etc)
+names:
+- Eric Yu
+
 # Is this the primary user of the site?
 superuser: false
 

--- a/content/authors/James-Scholz/_index.md
+++ b/content/authors/James-Scholz/_index.md
@@ -6,6 +6,10 @@ title: James Scholz
 authors:
 - James Scholz
 
+#Author Names (alternative spellings etc)
+names:
+- James Scholz
+
 # Is this the primary user of the site?
 superuser: false
 
@@ -27,7 +31,7 @@ organizations:
   url: ""
 
 # Short bio (displayed in user profile at end of posts)
-bio: My research interests include distributed robotics, mobile computing and programmable matter.
+#bio: My research interests include distributed robotics, mobile computing and programmable matter.
 
 interests:
 - Synthetic Biology

--- a/content/authors/Jet-Mante/_index.md
+++ b/content/authors/Jet-Mante/_index.md
@@ -6,6 +6,11 @@ title: Jet Mante
 authors:
 - Jet Mante
 
+#Author Names (alternative spellings etc)
+names:
+- Jet Mante
+- Jeanet Mante
+
 weight: 200
 
 # Is this the primary user of the site?
@@ -21,15 +26,15 @@ department:
 
 projects:
 - <a href="https://synbioks.github.io/">SBKS</a>
-- <a href="https://sbolcanvas.org/canvas/">SBOLCanvas</a>
+- <a href="https://synbiohub.github.io/aboutsynbiohub/">SynBioHub</a>
 
 # Organizations/Affiliations
 organizations:
-- name: University of Boulder, Colorado
+- name: University of Colorado Boulder
   url: ""
 
 # Short bio (displayed in user profile at end of posts)
-bio: My research interests include distributed robotics, mobile computing and programmable matter.
+#bio: My research interests include distributed robotics, mobile computing and programmable matter.
 
 interests:
 - Synthetic Biology
@@ -39,15 +44,12 @@ interests:
 
 education:
   courses:
-  - course: PhD in Artificial Intelligence
-    institution: Stanford University
-    year: 2012
-  - course: MEng in Artificial Intelligence
-    institution: Massachusetts Institute of Technology
-    year: 2009
-  - course: BSc in Artificial Intelligence
-    institution: Massachusetts Institute of Technology
-    year: 2008
+  - course: BA in Natural Sciences
+    institution: University of Cambridge
+    year: 2018
+  - course: PhD in Biomedical Engineering
+    institution: University of Colorado Boulder
+    year: 2022
 
 # Social/Academic Networking
 # For available icons, see: https://sourcethemes.com/academic/docs/page-builder/#icons
@@ -62,7 +64,7 @@ social:
 #   link: https://twitter.com/GeorgeCushen
 - icon: user-graduate
   icon_pack: fas
-  link: https://www.colorado.edu/ecee/
+  link: https://www.linkedin.com/in/jeanet-mante-590a24169
 - icon: github
   icon_pack: fab
   link: https://github.com/JMante1
@@ -71,7 +73,7 @@ social:
   link: https://orcid.org/0000-0002-1450-5638
 - icon: university-logo
   icon_pack: Custom_University
-  link: https://www.colorado.edu/ecee
+  link: https://www.colorado.edu/bme/academics/phd-program
 
 # Link to a PDF of your resume/CV from the About widget.
 # To enable, copy your resume/CV to `static/files/cv.pdf` and uncomment the lines below.
@@ -89,6 +91,6 @@ user_groups:
 - Graduate Students
 ---
 
+Jet Mante joined the Genetic Logic Lab as a Ph.D. student under the Supervision of Professor Chris Myers. She is a plant scientist whose research focuses on the reuse of data and genetic components in Synthetic Biology. She is expanding her computational skills working on search and curation methods in SynBioHub.
 
-What do the three images above have in common? The answer is that they can all be modeled and analyzed by methods being developed in the Myers Research Group. The first image is a timed asynchronous multiplier designed by Kip Killpack, the second image is a fully analog decoder for digital communication applications designed by several students as part of a joint project with Professors Christian Schlegel and Reid Harrison, and the third image is the Phage Lambda virus. Since 1991, we have been developing methods and tools for the design of timed asynchronous circuits. Since 2002, our research group has been extending our modeling and analysis methods to analyze and reason about both analog/mixed-signal circuits, as well as, biological systems. For more information about the research being conducted in our group, please see our research pages.\
-Over the years, this research has been supported by the National Science Foundation, the Semiconductor Research Corporation, Intel Corporation, and the State of Utah.
+She joined the lab in Utah after her undergraduate in England, and moved to CU Boulder with Professor Myers when he accepted a positon as ECE Departmental Chair. Jet is making the most of the move to Boulder by enjoying the bike friendly city and the many hiking trails.

--- a/content/authors/Logan-Terry/_index.md
+++ b/content/authors/Logan-Terry/_index.md
@@ -6,6 +6,10 @@ title: Logan Terry
 authors:
 - Logan Terry
 
+#Author Names (alternative spellings etc)
+names:
+- Logan Terry
+
 # Is this the primary user of the site?
 superuser: false
 

--- a/content/authors/Lukas-Buecherl/_index.md
+++ b/content/authors/Lukas-Buecherl/_index.md
@@ -5,6 +5,10 @@ title: Lukas Bücherl
 # Username (this should match the folder name)
 authors:
 - Lukas Buecherl
+
+#Author Names (alternative spellings etc)
+names:
+- Lukas Buecherl
 - Lukas Bücherl
 
 # Is this the primary user of the site?
@@ -30,7 +34,7 @@ organizations:
   url: ""
 
 # Short bio (displayed in user profile at end of posts)
-bio: My research interests include distributed robotics, mobile computing and programmable matter.
+#bio: My research interests include distributed robotics, mobile computing and programmable matter.
 
 interests:
 - Synthetic Biology
@@ -82,7 +86,7 @@ user_groups:
 - Graduate Students
 ---
 
-Lukas Buecherl joined the Genetic Logic Lab as Ph.D. student under the supervision of Dr. Chris Myers. He is a member of the IQ Biology program and his research focuses on synthetic biology and its possible applications in improving human lives. He is currently working in computational synthetic biology and plans to extend his knowledge with wet lab experience.
+Lukas Bücherl joined the Genetic Logic Lab as Ph.D. student under the supervision of Dr. Chris Myers. He is a member of the IQ Biology program and his research focuses on synthetic biology and its possible applications in improving human lives. He is currently working in computational synthetic biology and plans to extend his knowledge with wet lab experience.
 
 He was born and raised in Munich, Germany, and obtained a Bachelor of Science in electrical engineering from the University of Ulm, Germany, in 2019.
 As a member of the International Student Advisory Board, Lukas focuses on improving new international students' transition to the American academic system. Based on personal experience, he also wants to work on the acceptance of foreign letters in the system, since the german umlaut in his last name often causes problems with his visa and identification.

--- a/content/authors/Michael-Zhang/_index.md
+++ b/content/authors/Michael-Zhang/_index.md
@@ -6,6 +6,10 @@ title: Michael Zhang
 authors:
 - Michael Zhang
 
+#Author Names (alternative spellings etc)
+names:
+- Michael Zhang
+
 # Is this the primary user of the site?
 superuser: false
 

--- a/content/authors/Payton-Thomas/_index.md
+++ b/content/authors/Payton-Thomas/_index.md
@@ -6,6 +6,10 @@ title: Payton Thomas
 authors:
 - Payton Thomas
 
+#Author Names (alternative spellings etc)
+names:
+- Payton Thomas
+
 # Is this the primary user of the site?
 superuser: false
 
@@ -30,7 +34,7 @@ organizations:
   url: ""
 
 # Short bio (displayed in user profile at end of posts)
-bio: My research interests include distributed robotics, mobile computing and programmable matter.
+#bio: My research interests include distributed robotics, mobile computing and programmable matter.
 
 interests:
 - Synthetic Biology

--- a/content/authors/Pedro-Fontanarrosa/_index.md
+++ b/content/authors/Pedro-Fontanarrosa/_index.md
@@ -6,6 +6,10 @@ title: Pedro Fontanarrosa
 authors:
 - Pedro Fontanarrosa
 
+#Author Names (alternative spellings etc)
+names:
+- Pedro Fontanarrosa
+
 # Is this the primary user of the site?
 superuser: false
 
@@ -30,7 +34,7 @@ organizations:
   url: "https://www.bme.utah.edu/"
 
 # Short bio (displayed in user profile at end of posts)
-bio: My research interests include distributed robotics, mobile computing and programmable matter.
+#bio: My research interests include distributed robotics, mobile computing and programmable matter.
 
 interests:
 - Synthetic Biology
@@ -66,12 +70,13 @@ social:
 - icon: orcid
   icon_pack: fab
   link: https://orcid.org/0000-0002-1450-5638
-- icon: university-logo
-  icon_pack: Custom_University
-  link: https://www.bme.utah.edu/
 - icon: envelope
   icon_pack: fas
   link: mailto:pfontanarrosa@gmail.com  
+- icon: university-logo
+  icon_pack: Custom_University
+  link: https://www.bme.utah.edu/
+
 # Link to a PDF of your resume/CV from the About widget.
 # To enable, copy your resume/CV to `static/files/cv.pdf` and uncomment the lines below.
 #- icon: cv

--- a/content/authors/SBOL-Canvas/_index.md
+++ b/content/authors/SBOL-Canvas/_index.md
@@ -6,6 +6,10 @@ title: SBOL Canvas
 authors:
 - SBOL Canvas
 
+#Author Names (alternative spellings etc)
+names:
+- SBOL Canvas
+
 # Is this the primary user of the site?
 superuser: false
 

--- a/content/authors/Zach-Zundel/_index.md
+++ b/content/authors/Zach-Zundel/_index.md
@@ -9,6 +9,10 @@ weight: 830
 authors:
 - Zach Zundel
 
+#Author Names (alternative spellings etc)
+names:
+- Zach Zundel
+
 # Is this the primary user of the site?
 superuser: false
 

--- a/content/authors/admin/_index.md
+++ b/content/authors/admin/_index.md
@@ -6,6 +6,10 @@ title: Genetic Logic Lab
 authors:
 - admin
 
+#Author Names (alternative spellings etc)
+names:
+- admin
+
 # Is this the primary user of the site?
 superuser: true
 
@@ -14,11 +18,11 @@ superuser: true
 
 # Organizations/Affiliations
 organizations:
-- name: University of Boulder, Colorado
+- name: University of Colorado Boulder
   url: ""
 
 # Short bio (displayed in user profile at end of posts)
-bio: My research interests include distributed robotics, mobile computing and programmable matter.
+#bio: My research interests include distributed robotics, mobile computing and programmable matter.
 
 interests:
 - Synthetic Biology

--- a/layouts/authors/list.html
+++ b/layouts/authors/list.html
@@ -1,0 +1,90 @@
+{{- define "main" -}}
+
+{{/* Author profile page. */}}
+
+{{/* If an account has not been created for this user, just display their name as the title. */}}
+
+{{/* This list is a list of author 'stubs' which should re-direct */}}
+{{$redirectsFrom := slice "Jeanet Mante" "Chris J. Myers" "Chris J Myers"}}
+
+{{ if not .File }}
+  {{ if in $redirectsFrom .Title}}
+
+    {{/* For each set of aliases a new if statement is needed. */}}
+    {{/*Copy the line and replace the first list of aliases to redirect from and the second (e.g. jet-mante) with the page to redirect to*/}}
+    {{if in (slice "Chris J. Myers" "Chris J Myers") .Title}} {{.Scratch.Set "newAuthor" "chris-myers"}} {{end}}
+    {{if in (slice "Jeanet Mante") .Title}} {{.Scratch.Set "newAuthor" "jet-mante"}} {{end}}
+
+    {{$newAuthor := .Scratch.Get "newAuthor"}}
+    <head>
+      <title>/author/{{$newAuthor}}/</title>
+      <link rel="canonical" href="/author/{{$newAuthor}}/"/>
+      <meta name="robots" content="noindex">
+      <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+      <meta http-equiv="refresh" content="0; url=/author/{{$newAuthor}}/"/>
+    </head>
+  {{end}}
+<div class="universal-wrapper pt-3">
+  <h1>{{ .Title }}</h1>
+</div>
+{{ end }}
+
+<section id="profile-page" class="pt-5">
+  <div class="container">
+    {{/* Show the About widget if an account exists for this user. */}}
+    {{ if .File }}
+      {{ $widget := "widgets/about.html" }}
+      {{ $username := (path.Base (path.Split .Path).Dir) }}{{/* Alternatively, use `index .Params.authors 0` */}}
+      {{ $params := dict "root" $ "page" . "author" $username }}
+      {{ partial $widget $params }}
+    {{end}}
+
+    {{/* If _index.md exists for the author look through all site pages */}}
+    {{/* and display the articles that have an author equal to any of the names */}}
+    {{/* listed in the _index.md page */}}
+    {{ if .File }}
+      {{ $query := where .Site.Pages ".IsNode" false }}
+      {{ $count := len $query }}
+      {{$list := .Params.names}}
+
+      {{ if $count }}
+      <div class="article-widget content-widget-hr">
+        <h3>{{ i18n "user_profile_latest" | default "Latest" }}</h3>
+        <ul>
+          {{ range $query }}
+            {{$intersects := intersect $list .Params.authors}}
+            {{ if $intersects}}
+              <li>
+                <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+              </li>
+            {{ end}}
+          {{ end }}
+        </ul>
+      </div>
+      {{ end }}
+    {{end}}
+
+
+    {{/* If no _index.md file exists for the author */}}
+    {{/* list papers that have the same exact author listed */}}
+    {{ if not .File }}
+        {{ $query := where .Pages ".IsNode" false }}
+        {{ $count := len $query }}
+
+        {{ if $count }}
+        <div class="article-widget content-widget-hr">
+          <h3>{{ i18n "user_profile_latest" | default "Latest" }}</h3>
+          <ul>
+            {{ range $query }}
+                <li>
+                  <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+                </li>
+            {{ end }}
+          {{end}}
+          </ul>
+        </div>
+    {{end}}
+  </div>
+</section>
+
+{{- end -}}


### PR DESCRIPTION
changed the list.html to ensure that all articles by an author are shown on their page and that old author pages redirect to their main alias. Additionally, changed _index.md files of authors to ensure the changes to list.html are meaningful.

closes #38 